### PR TITLE
Fix dependency issue for log4j to repair some tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
       <version>5.1</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.5.6</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/org/sonar/plugins/resharper/CSharpReSharperProviderTest.java
+++ b/src/test/java/org/sonar/plugins/resharper/CSharpReSharperProviderTest.java
@@ -89,7 +89,6 @@ public class CSharpReSharperProviderTest {
   }
 
   @Test
-  @Ignore
   public void testSensorInstantiation() throws Exception {
     CSharpReSharperSensor sensor = new CSharpReSharperSensor(new Settings(), mock(RulesProfile.class), new DefaultFileSystem(Paths.get("")), mock(ResourcePerspectives.class));
     ReSharperConfiguration configuration = sensor.getConfiguration();
@@ -117,7 +116,6 @@ public class CSharpReSharperProviderTest {
   }
 
   @Test
-  @Ignore
   public void test_profile_importer() throws Exception {
     String content = "<wpf:ResourceDictionary xml:space=\"preserve\" xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\" xmlns:s=\"clr-namespace:System;assembly=mscorlib\" xmlns:ss=\"urn:shemas-jetbrains-com:settings-storage-xaml\" xmlns:wpf=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\">" +
       "<s:String x:Key=\"/Default/CodeInspection/Highlighting/InspectionSeverities/=key1/@EntryIndexedValue\">WARNING</s:String>" +

--- a/src/test/java/org/sonar/plugins/resharper/ReSharperProfileImporterTest.java
+++ b/src/test/java/org/sonar/plugins/resharper/ReSharperProfileImporterTest.java
@@ -20,7 +20,6 @@
 package org.sonar.plugins.resharper;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.sonar.api.profiles.RulesProfile;
 import org.sonar.api.rules.ActiveRule;
@@ -35,7 +34,6 @@ import static org.fest.assertions.Assertions.assertThat;
 public class ReSharperProfileImporterTest {
 
   @Test
-  @Ignore
   public void test_invalid_xml() throws Exception {
     String content = "<wpf:ResourceDictionary xml:space=\"preserve\" xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\" xmlns:s=\"clr-namespace:System;assembly=mscorlib\" xmlns:ss=\"urn:shemas-jetbrains-com:settings-storage-xaml\" xmlns:wpf=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\">\n" +
       "  <s:String x:Key=\"/Defa";
@@ -50,7 +48,6 @@ public class ReSharperProfileImporterTest {
   }
 
   @Test
-  @Ignore
   public void test_invalid_root_element() throws Exception {
     String content = "<bad xml:space=\"preserve\" xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\" xmlns:s=\"clr-namespace:System;assembly=mscorlib\" xmlns:ss=\"urn:shemas-jetbrains-com:settings-storage-xaml\" xmlns:wpf=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\">\n" +
       "  <s:String x:Key=\"/Default/CodeInspection/Highlighting/InspectionSeverities/=key1/@EntryIndexedValue\">WARNING</s:String>\n" +
@@ -64,7 +61,6 @@ public class ReSharperProfileImporterTest {
   }
 
   @Test
-  @Ignore
   public void test_profile_importer() throws Exception {
     String content = "<wpf:ResourceDictionary xml:space=\"preserve\" xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\" xmlns:s=\"clr-namespace:System;assembly=mscorlib\" xmlns:ss=\"urn:shemas-jetbrains-com:settings-storage-xaml\" xmlns:wpf=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\">" +
       "<s:String x:Key=\"/Default/CodeInspection/Highlighting/InspectionSeverities/=key1/@EntryIndexedValue\">WARNING</s:String>" +

--- a/src/test/java/org/sonar/plugins/resharper/ReSharperSensorTest.java
+++ b/src/test/java/org/sonar/plugins/resharper/ReSharperSensorTest.java
@@ -59,7 +59,6 @@ public class ReSharperSensorTest {
   public ExpectedException thrown = ExpectedException.none();
 
   @Test
-  @Ignore
   public void shouldExecuteOnProject() {
     Settings settings = mock(Settings.class);
     RulesProfile profile = mock(RulesProfile.class);
@@ -231,7 +230,6 @@ public class ReSharperSensorTest {
   }
 
   @Test
-  @Ignore
   public void check_project_name_property() {
     thrown.expectMessage(ReSharperPlugin.CS_REPORT_PATH_KEY);
     thrown.expect(IllegalStateException.class);
@@ -241,7 +239,6 @@ public class ReSharperSensorTest {
   }
 
   @Test
-  @Ignore
   public void check_solution_file_property() {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage(ReSharperPlugin.SOLUTION_FILE_PROPERTY_KEY);

--- a/src/test/java/org/sonar/plugins/resharper/VBNetReSharperProviderTest.java
+++ b/src/test/java/org/sonar/plugins/resharper/VBNetReSharperProviderTest.java
@@ -89,7 +89,6 @@ public class VBNetReSharperProviderTest {
   }
 
   @Test
-  @Ignore
   public void testSensorInstantiation() throws Exception {
     VBNetReSharperSensor sensor = new VBNetReSharperSensor(new Settings(), mock(RulesProfile.class), new DefaultFileSystem(Paths.get("")), mock(ResourcePerspectives.class));
     ReSharperConfiguration configuration = sensor.getConfiguration();
@@ -115,7 +114,6 @@ public class VBNetReSharperProviderTest {
   }
 
   @Test
-  @Ignore
   public void test_profile_importer() throws Exception {
     String content = "<wpf:ResourceDictionary xml:space=\"preserve\" xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\" xmlns:s=\"clr-namespace:System;assembly=mscorlib\" xmlns:ss=\"urn:shemas-jetbrains-com:settings-storage-xaml\" xmlns:wpf=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\">" +
       "<s:String x:Key=\"/Default/CodeInspection/Highlighting/InspectionSeverities/=key1/@EntryIndexedValue\">WARNING</s:String>" +


### PR DESCRIPTION
In #3, we deactivate some tests, so that the build runs again. So a few of these tests are failed, because of an missing dependency. Therefore fix that dependency issue, so that these tests run again.